### PR TITLE
Handle scenario where metric name is padded with spaces

### DIFF
--- a/nsd_exporter.go
+++ b/nsd_exporter.go
@@ -58,7 +58,7 @@ func (c *NSDCollector) Collect(ch chan<- prometheus.Metric) {
 	s := bufio.NewScanner(r)
 	for s.Scan() {
 		line := strings.Split(s.Text(), "=")
-		metricName := line[0]
+		metricName := strings.TrimSpace(line[0])
 		m, ok := c.metrics[metricName]
 		if !ok {
 			log.Println("Unknown Metric ", metricName, ". Skipping.")


### PR DESCRIPTION
Fixes this:

`2019/02/21 02:06:59 Unknown Metric  num.type.TYPE255 . Skipping.`
`2019/02/21 02:07:14 Unknown Metric  num.type.TYPE255 . Skipping.`
`2019/02/21 02:07:29 Unknown Metric  num.type.TYPE255 . Skipping.`
`2019/02/21 02:07:44 Unknown Metric  num.type.TYPE255 . Skipping.`
`2019/02/21 02:07:59 Unknown Metric  num.type.TYPE255 . Skipping.`
`2019/02/21 02:08:14 Unknown Metric  num.type.TYPE255 . Skipping.`
`2019/02/21 02:08:29 Unknown Metric  num.type.TYPE255 . Skipping.`
`2019/02/21 02:08:44 Unknown Metric  num.type.TYPE255 . Skipping.`